### PR TITLE
Updated package.json to point to our team's stuff.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-models",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "description": "Shared models and validation for the Bicycle Touring Companion",
   "scripts": {
     "prepublish": "npm run build",
@@ -25,14 +25,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bikelomatic-complexity/btc-models.git"
+    "url": "git+https://github.com/tour-de-force/btc-models.git"
   },
   "author": "Steven Kroh",
   "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/bikelomatic-complexity/btc-models/issues"
+    "url": "https://github.com/tour-de-force/btc-models/issues"
   },
-  "homepage": "https://github.com/bikelomatic-complexity/btc-models#readme",
+  "homepage": "https://github.com/tour-de-force/btc-models#readme",
   "main": "lib/index.js",
   "dependencies": {
     "ajv": "^3.7.1",


### PR DESCRIPTION
Bumped version number to 1.0.0 to match Cordova (but with an extra .0 to match NPM convention).

https://github.com/Tour-de-Force/btc-models/issues/7
